### PR TITLE
Support bool data type. Freetds bugfix.

### DIFF
--- a/executesql.go
+++ b/executesql.go
@@ -68,9 +68,14 @@ func quote(in string) string {
 }
 
 func go2SqlDataType(value interface{}) (string, string) {
-	//TODO - bool value
 	strValue := fmt.Sprintf("%v", value)
 	switch t := value.(type) {
+	case bool:
+		bitStrValue := "0"
+		if strValue = "true" {
+			bitStrValue = "1"
+		}
+		return "bit", bitStrValue
 	case uint8, int8:
 		return "tinyint", strValue
 	case uint16, int16:

--- a/executesql.go
+++ b/executesql.go
@@ -60,6 +60,9 @@ func parseParams(params ...driver.Value) (paramDef, paramVal string) {
 		paramDef += fmt.Sprintf("%s %s", paramName, sqlType)
 		paramVal += fmt.Sprintf("%s=%s", paramName, sqlValue)
 	}
+	log.Printf("paramDef: ", paramDef, " paramVal: ", paramVal)
+	paramDef = strings.Replace(paramDef, "nvarchar (0)", "nvarchar (1)", -1)
+	log.Printf("modified paramDef: ", paramDef)
 	return
 }
 
@@ -72,7 +75,7 @@ func go2SqlDataType(value interface{}) (string, string) {
 	switch t := value.(type) {
 	case bool:
 		bitStrValue := "0"
-		if strValue = "true" {
+		if strValue == "true" {
 			bitStrValue = "1"
 		}
 		return "bit", bitStrValue

--- a/executesql.go
+++ b/executesql.go
@@ -60,9 +60,7 @@ func parseParams(params ...driver.Value) (paramDef, paramVal string) {
 		paramDef += fmt.Sprintf("%s %s", paramName, sqlType)
 		paramVal += fmt.Sprintf("%s=%s", paramName, sqlValue)
 	}
-	log.Printf("paramDef: ", paramDef, " paramVal: ", paramVal)
 	paramDef = strings.Replace(paramDef, "nvarchar (0)", "nvarchar (1)", -1)
-	log.Printf("modified paramDef: ", paramDef)
 	return
 }
 


### PR DESCRIPTION
Added support for bool-to-bit data type mapping. I'm not sure if this covers all cases or is only relevant for sql.

Freetds bugfix refers to a bug I am encountering that seems to be a known issue in freetds itself when using it against sql express. I am getting an error (Length or precision specification 0 is
invalid) when I try to set a non-nullable nvarchar field with an empty string. It seems the only way around this issue is to patch freetds itself, so as a workaround this fix is a hack which changes anything with varchar(0) to varchar(1) - it's ugly but it circumvents the freetds problem entirely without having to modify the actual string to contain something like a space, which others have suggested.

Rreferences:
Another person reporting same issue: http://osdir.com/ml/db.tds.freetds/2004-08/msg00022.html
Resolution to the issue was a patch to freetds: http://osdir.com/ml/db.tds.freetds/2004-08/msg00030.html