### PR TITLE
Fix datetime insert

### DIFF
--- a/executesql.go
+++ b/executesql.go
@@ -97,8 +97,8 @@ func go2SqlDataType(value interface{}) (string, string) {
 		}
 	case time.Time:
 		{
-			t, _ := value.(time.Time)
-			strValue = t.Format(time.RFC3339)
+			strValue = t.Format(time.RFC3339Nano)
+			return "datetimeoffset", fmt.Sprintf("'%s'", quote(strValue))
 		}
 	case []byte:
 		{


### PR DESCRIPTION
MsSQL doesn't like using RFC3339 for `datetime` columns, giving a generic:

```
Conversion failed when converting date and/or time from character string.
```

By using a `datetimeoffset` instead of an `nvarchar`, the server can not only parse RFC3339 but also
automatically cast to any other date type.