### PR TITLE
Added SQL Max and Min datetime support

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -176,11 +176,11 @@ func (p *ConnPool) Close() {
 }
 
 func (p *ConnPool) cleanup() {
+	p.poolMutex.Lock()
+	defer p.poolMutex.Unlock()
 	if len(p.pool) <= 1 {
 		return
 	}
-	p.poolMutex.Lock()
-	defer p.poolMutex.Unlock()
 	for i := len(p.pool) - 2; i >= 0; i-- {
 		conn := p.pool[i]
 		if conn.expiresFromPool.Before(time.Now()) {

--- a/conn_pool.go
+++ b/conn_pool.go
@@ -193,6 +193,8 @@ func (p *ConnPool) cleanup() {
 
 //Statistic about connections in the pool.
 func (p *ConnPool) Stat() (max, count, active int) {
+        p.poolMutex.Lock()
+        defer p.poolMutex.Unlock()
 	max = p.maxConn
 	count = p.connCount
 	inactive := len(p.pool)

--- a/convert_sql_buf_test.go
+++ b/convert_sql_buf_test.go
@@ -82,7 +82,7 @@ func TestTime(t *testing.T) {
 	f(time.Now().UTC())
 	f(time.Unix(1404856800, 0))
 	f(time.Unix(1404856800, 0).UTC())
-	// f(SqlMaxTime) can't test.
+	f(SqlMaxTime)
 	f(SqlMinTime)
 }
 

--- a/convert_sql_buf_test.go
+++ b/convert_sql_buf_test.go
@@ -82,6 +82,8 @@ func TestTime(t *testing.T) {
 	f(time.Now().UTC())
 	f(time.Unix(1404856800, 0))
 	f(time.Unix(1404856800, 0).UTC())
+	// f(SqlMaxTime) can't test.
+	f(SqlMinTime)
 }
 
 func TestTime4(t *testing.T) {


### PR DESCRIPTION
In response to my issue #18 please review this pull request to add constant support for SQL Min and Max datetime values.

I believe there is still an issue within the gofreetds package when using very high value datetimes, but I'm not sure this can be avoiding given the limitations of the underlying time.Time type.
Someone a lot better at math than me might be able to figure it out :-)

The Max constants come from this URL https://ask.sqlservercentral.com/questions/17549/php-with-mssql-strtotime-with-mssql-datetime-colum.html 
Both the Min and Max datetime constants appear correctly in my SQL Server 2014 database.

Update, 09 Jan 2016: I've also made a minor change in conn_poo.go which resolves a Data Race reported when gofreetds is built and run when using the Go Race Detector.

Thank you. 
Mark Songhurst