### PR TITLE
Revert "Added SQL Max and Min datetime support"

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -176,11 +176,11 @@ func (p *ConnPool) Close() {
 }
 
 func (p *ConnPool) cleanup() {
-	p.poolMutex.Lock()
-	defer p.poolMutex.Unlock()
 	if len(p.pool) <= 1 {
 		return
 	}
+	p.poolMutex.Lock()
+	defer p.poolMutex.Unlock()
 	for i := len(p.pool) - 2; i >= 0; i-- {
 		conn := p.pool[i]
 		if conn.expiresFromPool.Before(time.Now()) {
@@ -193,8 +193,6 @@ func (p *ConnPool) cleanup() {
 
 //Statistic about connections in the pool.
 func (p *ConnPool) Stat() (max, count, active int) {
-        p.poolMutex.Lock()
-        defer p.poolMutex.Unlock()
 	max = p.maxConn
 	count = p.connCount
 	inactive := len(p.pool)

--- a/convert_sql_buf.go
+++ b/convert_sql_buf.go
@@ -48,16 +48,6 @@ const (
 
 var sqlStartTime = time.Date(1900, 1, 1, 0, 0, 0, 0, time.UTC)
 
-var SqlMinTime = time.Date(1753, 01, 01, 00, 00, 00, 000, time.UTC)
-
-const sqlMaxTimeDays int32 = 2958463
-const sqlMaxTimeSec uint32 = 25919999
-
-var SqlMaxTime = time.Date(9999, 12, 31, 23, 59, 59, 997, time.UTC)
-
-const sqlMinTimeDays int32 = -53690
-const sqlMinTimeSec uint32 = 0
-
 func toLocalTime(value time.Time) time.Time {
 	value = value.In(time.Local)
 	_, of := value.Zone()
@@ -89,12 +79,8 @@ func sqlBufToType(datatype int, data []byte) interface{} {
 		var sec uint32 /* 300ths of a second since midnight */
 		binary.Read(buf, binary.LittleEndian, &days)
 		binary.Read(buf, binary.LittleEndian, &sec)
-		if days == sqlMaxTimeDays && sec == sqlMaxTimeSec {
-			return toLocalTime(SqlMaxTime)
-		} else {
-			value := sqlStartTime.Add(time.Duration(days) * time.Hour * 24).Add(time.Duration(sec) * time.Second / 300)
-			return toLocalTime(value)
-		}
+		value := sqlStartTime.Add(time.Duration(days) * time.Hour * 24).Add(time.Duration(sec) * time.Second / 300)
+		return toLocalTime(value)
 	case SYBDATETIME4:
 		var days uint16 /* number of days since 1/1/1900 */
 		var mins uint16 /* number of minutes since midnight */
@@ -200,24 +186,12 @@ func typeToSqlBuf(datatype int, value interface{}, freetdsVersionGte095 bool) (d
 	case SYBDATETIME:
 		//database time is always in local timezone
 		if tm, ok := value.(time.Time); ok {
-			var days int32
-			var secs uint32
-
-			// Skip the math and just use constants for SQL Max or Min Time
-			if tm.Equal(SqlMaxTime) {
-				days = sqlMaxTimeDays
-				secs = sqlMaxTimeSec
-			} else if tm.Equal(SqlMinTime) {
-				days = sqlMinTimeDays
-				secs = sqlMinTimeSec
-			} else {
-				tm = tm.Local()
-				diff := tm.UnixNano() - sqlStartTime.UnixNano()
-				_, of := tm.Zone()
-				diff += int64(time.Duration(of) * time.Second)
-				days = int32(diff / 1e9 / 60 / 60 / 24)
-				secs = uint32(float64(diff-int64(days)*1e9*60*60*24) * 0.0000003)
-			}
+			tm = tm.Local()
+			diff := tm.UnixNano() - sqlStartTime.UnixNano()
+			_, of := tm.Zone()
+			diff += int64(time.Duration(of) * time.Second)
+			days := int32(diff / 1e9 / 60 / 60 / 24)
+			secs := uint32(float64(diff-int64(days)*1e9*60*60*24) * 0.0000003)
 			err = binary.Write(buf, binary.LittleEndian, days)
 			if err == nil {
 				err = binary.Write(buf, binary.LittleEndian, secs)

--- a/convert_sql_buf_test.go
+++ b/convert_sql_buf_test.go
@@ -82,8 +82,6 @@ func TestTime(t *testing.T) {
 	f(time.Now().UTC())
 	f(time.Unix(1404856800, 0))
 	f(time.Unix(1404856800, 0).UTC())
-	f(SqlMaxTime)
-	f(SqlMinTime)
 }
 
 func TestTime4(t *testing.T) {


### PR DESCRIPTION
Reverts minus5/gofreetds#19

I found a failing test:
```
--- FAIL: TestTime (0.00s)
	convert_sql_buf_test.go:78: TestTime 9999-12-31 23:59:59.000000997 +0000 UTC != 9999-12-31 23:59:59.000000997 +0100 CET diff: -3600000000000
	convert_sql_buf_test.go:78: TestTime 1753-01-01 00:00:00 +0000 UTC != 1753-01-01 00:00:00 +0100 CET diff: -3600000000000
```

I'm in CET timezone...

