### PR TITLE
Resolved Go race condition

### DIFF
--- a/conn_pool.go
+++ b/conn_pool.go
@@ -74,6 +74,9 @@ func NewConnPool(connStr string) (*ConnPool, error) {
 }
 
 func (p *ConnPool) newConn() (*Conn, error) {
+	p.poolMutex.Lock()
+	defer p.poolMutex.Unlock()
+
 	conn, err := NewConn(p.connStr)
 	if err == nil {
 		conn.belongsToPool = p


### PR DESCRIPTION
Added pooMutex locks into newConn to resolve a race condition reported by the Go race condition tester.