### PR TITLE
Sybase compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo apt-get install freetds-dev
 ### Go get
 
 ```
-go get github.com/minus5/gofreetds 
+go get github.com/minus5/gofreetds
 ```
 
 ### Docs
@@ -108,6 +108,10 @@ Execute query with params:
 ```go
 rst, err := conn.ExecuteSql("select au_id, au_lname, au_fname from authors where au_id = ?", "998-72-3567")
 ```
+
+## Sybase Compatibility Mode
+
+This is some examples of using Sybase ASE 16 with gofreetds.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Features:
 
 ##Get started
 
-###Instal dependencines
+###Install dependencines
 
 [FreeTDS](http://www.freetds.org/) libraries must be installed on the system.
 
@@ -111,13 +111,20 @@ rst, err := conn.ExecuteSql("select au_id, au_lname, au_fname from authors where
 
 ## Sybase Compatibility Mode
 
+Gofreetds now supports Sybase ASE 16.0 through the driver. In order to support this, this post is very helpful: [Connect to MS SQL Server and Sybase ASE from Mac OS X and Linux with unixODBC and FreeTDS](http://2tbsp.com/articles/2012/06/08/connect-ms-sql-server-and-sybase-ase-mac-os-x-and-linux-unixodbc-and-freetds)
+
+To use a Sybase ASE server with Gofreetds, you simply need to set a compatibility mode on your connection string after you've configured your .odbc.ini file and .freetds.conf file.
+
+This mode uses TDS Version 5.
+
 ### Connection String Parameter
+
+You can set your connection string up for Sybase by using the 'compatibility_mode' Parameter. The parameter can be named 'compatibility', 'compatibility mode', 'compatibility_mode' or 'Compatibility Mode'. Currently this mode only supports Sybase. To specify you can use 'sybase' or 'Sybase'.
 
 ```
 Server=myServerAddress;Database=myDatabase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Compatibility Mode=Sybase
 ```
 
-This is some examples of using Sybase ASE 16 with gofreetds.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ rst, err := conn.ExecuteSql("select au_id, au_lname, au_fname from authors where
 
 ## Sybase Compatibility Mode
 
+### Connection String Parameter
+
+```
+Server=myServerAddress;Database=myDatabase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Compatibility Mode=Sybase
+```
+
 This is some examples of using Sybase ASE 16 with gofreetds.
 
 ## Testing

--- a/conn.go
+++ b/conn.go
@@ -45,7 +45,7 @@ import (
   DBSETLUSER(login, username);
   DBSETLPWD(login, password);
   dbsetlname(login, "UTF-8", DBSETCHARSET);
-  dbsetlversion(login, DBVERSION_72);
+  //dbsetlversion(login, DBVERSION_72);
  }
 
  static long dbproc_addr(DBPROCESS * dbproc) {
@@ -338,12 +338,12 @@ func (conn *Conn) MirrorStatus() (bool, bool, bool, error) {
 	rst, err := conn.exec(fmt.Sprintf(`
     SELECT
     	case when mirroring_guid is not null then 1 else 0 end mirroring_active,
-    	case when mirroring_role = 2 then 0 else 1 end is_master, 
+    	case when mirroring_role = 2 then 0 else 1 end is_master,
     	mirroring_state, mirroring_state_desc, mirroring_role, mirroring_role_desc,
-      database_id, 
-    	DB_NAME(database_id) database_name     	
+      database_id,
+    	DB_NAME(database_id) database_name
     FROM sys.database_mirroring
-    WHERE DB_NAME(database_id)='%s' 
+    WHERE DB_NAME(database_id)='%s'
   `, conn.database))
 	if err != nil {
 		return true, false, false, err
@@ -355,15 +355,18 @@ func (conn *Conn) MirrorStatus() (bool, bool, bool, error) {
 }
 
 func (conn *Conn) setDefaults() error {
-	//defaults copied from .Net Driver
-	_, err := conn.exec(`
-    set quoted_identifier on
-    set ansi_warnings on
-    set ansi_padding off
-    set concat_null_yields_null on
-   `)
-	if err != nil {
-		return err
+	var err error
+	if conn.credentials.compatibility != "sybase" {
+		//defaults copied from .Net Driver
+		_, err = conn.exec(`
+	    set quoted_identifier on
+	    set ansi_warnings on
+	    set ansi_padding off
+	    set concat_null_yields_null on
+	   `)
+		if err != nil {
+			return err
+		}
 	}
 	if t := conn.credentials.lockTimeout; t > 0 {
 		_, err = conn.exec(fmt.Sprintf("set lock_timeout %d", t))

--- a/conn.go
+++ b/conn.go
@@ -374,10 +374,10 @@ func (conn *Conn) setDefaults() error {
 	if conn.credentials.compatibility != SYBASE {
 		//defaults copied from .Net Driver
 		_, err = conn.exec(`
-	    		set quoted_identifier on
-			set ansi_warnings on
-	    		set ansi_padding off
-	    		set concat_null_yields_null on
+				set quoted_identifier on
+				set ansi_warnings on
+	    	set ansi_padding off
+				set concat_null_yields_null on
 	   	`)
 		if err != nil {
 			return err

--- a/conn.go
+++ b/conn.go
@@ -374,10 +374,10 @@ func (conn *Conn) setDefaults() error {
 	if conn.credentials.compatibility != SYBASE {
 		//defaults copied from .Net Driver
 		_, err = conn.exec(`
-				set quoted_identifier on
-				set ansi_warnings on
-	    	set ansi_padding off
-				set concat_null_yields_null on
+        set quoted_identifier on
+        set ansi_warnings on
+        set ansi_padding off
+        set concat_null_yields_null on
 	   	`)
 		if err != nil {
 			return err

--- a/credentials.go
+++ b/credentials.go
@@ -7,7 +7,7 @@ import (
 
 type credentials struct {
 	user, pwd, host, database, mirrorHost, compatibility string
-	maxPoolSize, lockTimeout              							 int
+	maxPoolSize, lockTimeout int
 }
 
 func NewCredentials(connStr string) *credentials {

--- a/credentials.go
+++ b/credentials.go
@@ -6,8 +6,8 @@ import (
 )
 
 type credentials struct {
-	user, pwd, host, database, mirrorHost string
-	maxPoolSize, lockTimeout              int
+	user, pwd, host, database, mirrorHost, compatibility string
+	maxPoolSize, lockTimeout              							 int
 }
 
 func NewCredentials(connStr string) *credentials {
@@ -33,6 +33,8 @@ func NewCredentials(connStr string) *credentials {
 				if i, err := strconv.Atoi(value); err == nil {
 					crd.maxPoolSize = i
 				}
+			case "compatibility_mode", "compatibility mode", "compatibility":
+				crd.compatibility = value
 			case "lock timeout", "lock_timeout":
 				if i, err := strconv.Atoi(value); err == nil {
 					crd.lockTimeout = i

--- a/credentials.go
+++ b/credentials.go
@@ -34,7 +34,7 @@ func NewCredentials(connStr string) *credentials {
 					crd.maxPoolSize = i
 				}
 			case "compatibility_mode", "compatibility mode", "compatibility":
-				crd.compatibility = value
+				crd.compatibility = strings.ToLower(value)
 			case "lock timeout", "lock_timeout":
 				if i, err := strconv.Atoi(value); err == nil {
 					crd.lockTimeout = i

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -8,11 +8,12 @@ import (
 
 func TestParseConnectionString(t *testing.T) {
 	validConnStrings := []string{
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000",
-		"Server=myServerAddress;Database=myDataBase;User_Id=myUsername;Password=myPassword;Failover_Partner=myMirror;Max_Pool_Size=200;Lock_Timeout=1000",
-		"server=myServerAddress;database=myDataBase;user_id=myUsername;password=myPassword;failover_partner=myMirror;max_pool_size=200;lock_timeout=1000",
-		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
-		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000,Compatibility Mode=sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000,Compatibility_Mode=sybase",
+		"Server=myServerAddress;Database=myDataBase;User_Id=myUsername;Password=myPassword;Failover_Partner=myMirror;Max_Pool_Size=200;Lock_Timeout=1000,Compatibility=sybase",
+		"server=myServerAddress;database=myDataBase;user_id=myUsername;password=myPassword;failover_partner=myMirror;max_pool_size=200;lock_timeout=1000,compatibility_mode=sybase",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000,compatibility mode=sybase",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000,compatibility=sybase",
 	}
 	for _, connStr := range validConnStrings {
 		testCredentials(t, NewCredentials(connStr))
@@ -28,4 +29,5 @@ func testCredentials(t *testing.T, crd *credentials) {
 	assert.Equal(t, "myMirror", crd.mirrorHost)
 	assert.Equal(t, 200, crd.maxPoolSize)
 	assert.Equal(t, 1000, crd.lockTimeout)
+	assert.Equal(t, "sybase", crd.compatibility)
 }

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -9,10 +9,8 @@ import (
 func TestParseConnectionString(t *testing.T) {
 	validConnStrings := []string{
 		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000",
 		"Server=myServerAddress;Database=myDataBase;User_Id=myUsername;Password=myPassword;Failover_Partner=myMirror;Max_Pool_Size=200;Lock_Timeout=1000",
 		"server=myServerAddress;database=myDataBase;user_id=myUsername;password=myPassword;failover_partner=myMirror;max_pool_size=200;lock_timeout=1000",
-		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
 		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
 		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
 	}

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -8,12 +8,13 @@ import (
 
 func TestParseConnectionString(t *testing.T) {
 	validConnStrings := []string{
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility Mode=sybase",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility_Mode=sybase",
-		"Server=myServerAddress;Database=myDataBase;User_Id=myUsername;Password=myPassword;Failover_Partner=myMirror;Max_Pool_Size=200;Lock_Timeout=1000;Compatibility=sybase",
-		"server=myServerAddress;database=myDataBase;user_id=myUsername;password=myPassword;failover_partner=myMirror;max_pool_size=200;lock_timeout=1000;compatibility_mode=sybase",
-		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000;compatibility mode=sybase",
-		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000;compatibility=sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000",
+		"Server=myServerAddress;Database=myDataBase;User_Id=myUsername;Password=myPassword;Failover_Partner=myMirror;Max_Pool_Size=200;Lock_Timeout=1000",
+		"server=myServerAddress;database=myDataBase;user_id=myUsername;password=myPassword;failover_partner=myMirror;max_pool_size=200;lock_timeout=1000",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000",
 	}
 	for _, connStr := range validConnStrings {
 		testCredentials(t, NewCredentials(connStr))
@@ -29,5 +30,28 @@ func testCredentials(t *testing.T, crd *credentials) {
 	assert.Equal(t, "myMirror", crd.mirrorHost)
 	assert.Equal(t, 200, crd.maxPoolSize)
 	assert.Equal(t, 1000, crd.lockTimeout)
-	assert.Equal(t, "sybase", crd.compatibility)
+}
+
+func TestParseConnectionStringCompatibilityMode(t *testing.T) {
+	setDefaultStrings := map[string]string {
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000": "",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility_mode=Sybase": "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility mode=sybase": "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility Mode=sybase": "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility_Mode=Sybase": "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility=Other": "other",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility=other": "other",
+	}
+	for connStr,expected := range setDefaultStrings {
+		crd := NewCredentials(connStr)
+		assert.NotNil(t, crd)
+		assert.Equal(t, "myServerAddress", crd.host)
+		assert.Equal(t, "myDataBase", crd.database)
+		assert.Equal(t, "myUsername", crd.user)
+		assert.Equal(t, "myPassword", crd.pwd)
+		assert.Equal(t, "myMirror", crd.mirrorHost)
+		assert.Equal(t, 200, crd.maxPoolSize)
+		assert.Equal(t, 1000, crd.lockTimeout)
+		assert.Equal(t, expected, crd.compatibility)
+	}
 }

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -8,12 +8,12 @@ import (
 
 func TestParseConnectionString(t *testing.T) {
 	validConnStrings := []string{
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000,Compatibility Mode=sybase",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000,Compatibility_Mode=sybase",
-		"Server=myServerAddress;Database=myDataBase;User_Id=myUsername;Password=myPassword;Failover_Partner=myMirror;Max_Pool_Size=200;Lock_Timeout=1000,Compatibility=sybase",
-		"server=myServerAddress;database=myDataBase;user_id=myUsername;password=myPassword;failover_partner=myMirror;max_pool_size=200;lock_timeout=1000,compatibility_mode=sybase",
-		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000,compatibility mode=sybase",
-		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000,compatibility=sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility Mode=sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility_Mode=sybase",
+		"Server=myServerAddress;Database=myDataBase;User_Id=myUsername;Password=myPassword;Failover_Partner=myMirror;Max_Pool_Size=200;Lock_Timeout=1000;Compatibility=sybase",
+		"server=myServerAddress;database=myDataBase;user_id=myUsername;password=myPassword;failover_partner=myMirror;max_pool_size=200;lock_timeout=1000;compatibility_mode=sybase",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000;compatibility mode=sybase",
+		"host=myServerAddress;database=myDataBase;user=myUsername;pwd=myPassword;mirror=myMirror;max_pool_size=200;lock_timeout=1000;compatibility=sybase",
 	}
 	for _, connStr := range validConnStrings {
 		testCredentials(t, NewCredentials(connStr))


### PR DESCRIPTION
Adds compatibility mode. A single connection string parameter: "Compatibility Mode" in multiple formats. 
README updated to include "sybase" mode. 
Tested on Sybase ASE 16. Should not break any compatibility with Microsoft SQL Server. Not a required connection string parameter.