### PR TITLE
Fix inability to use ExecSp against Sybase ASE

### DIFF
--- a/conn_sp_test.go
+++ b/conn_sp_test.go
@@ -140,23 +140,22 @@ func TestGetSpParams(t *testing.T) {
 	assert.Equal(t, int(p.Scale), 0x0)
 }
 
-func TestGetSpParamsSql(t *testing.T) {
-	testSpName := "test_get_sp_params"
-
-	var conn *Conn
-	var expectedSql, actualSql string
-
-	conn = &Conn{}
-	expectedSql = fmt.Sprintf(msSqlGetSpParamsSql, testSpName)
-	actualSql = conn.getSpParamsSql(testSpName)
+func TestGetSpParamsSqlMsSql(t *testing.T) {
+	testSpName := "test_get_sp_params_sql"
+	conn := &Conn{}
+	expectedSql := fmt.Sprintf(msSqlGetSpParamsSql, testSpName)
+	actualSql := conn.getSpParamsSql(testSpName)
 	assert.Equal(t, expectedSql, actualSql)
+}
 
+func TestGetSpParamsSqlSybase(t *testing.T) {
+	testSpName := "test_get_sp_params_sql"
 	creds := NewCredentials("Compatibility Mode=Sybase")
-	conn = &Conn{
+	conn := &Conn{
 		credentials: *creds,
 	}
-	expectedSql = fmt.Sprintf(sybaseAseGetSpParamsSql, testSpName)
-	actualSql = conn.getSpParamsSql(testSpName)
+	expectedSql := fmt.Sprintf(sybaseAseGetSpParamsSql, testSpName)
+	actualSql := conn.getSpParamsSql(testSpName)
 	assert.Equal(t, expectedSql, actualSql)
 }
 


### PR DESCRIPTION
Fixes the inability to use ExecSp against a Sybase ASE database when calling a stored procedure. 

This PR uses [the newly-introduced Sybase compatibility mode setting](https://github.com/minus5/gofreetds#sybase-compatibility-mode) on the connection string to decide whether to use a MSSQL-specific or Sybase-specific SQL command to use in getting a list of stored procedure parameters for a given stored procedure 

While you can just use the Exec method to execute a stored procedure that only involves returned result sets, you are forced to use ExecSp when your stored procedure returns data in output parameters. In initial usage of ExecSp, I received this error:

```
Msg 20018, Level 16
General SQL Server error: Check messages from the SQL Server


Msg 20018, Level 16
General SQL Server error: Check messages from the SQL Server


Msg 208, Level 16, State 1
Server 'SYBASE', Line 2
	sys.all_parameters not found. Specify owner.objectname or use sp_help to check whether the object exists (sp_help may produce lots of output).


Msg 208, Level 16, State 1
Server 'SYBASE', Line 2
	sys.all_objects not found. Specify owner.objectname or use sp_help to check whether the object exists (sp_help may produce lots of output).
```

Added a couple of unit tests to exercise the conditional logic as well.