### PR TITLE
Added map to count occurrances of FreeTDS message numbers

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -65,7 +65,7 @@ func msgHandler(dbprocAddr C.long, msgno C.DBINT, msgstate, severity C.int, msgt
 	lastMessage = msg
 	conn := getConnection(int64(dbprocAddr))
 	if conn != nil {
-		conn.addMessage(msg)
+		conn.addMessage(msg, int(msgno))
 	}
 
 	//fmt.Printf("msg: %s", msg)

--- a/callbacks.go
+++ b/callbacks.go
@@ -30,7 +30,7 @@ func errHandler(dbprocAddr C.long, severity, dberr, oserr C.int, dberrstr, oserr
 	}
 	err += fmt.Sprintf("\n%s\n\n", C.GoString(dberrstr))
 
-	lastErrorMutex.Lock()	
+	lastErrorMutex.Lock()
 	lastError = err
 	lastErrorMutex.Unlock()
 
@@ -71,7 +71,7 @@ func msgHandler(dbprocAddr C.long, msgno C.DBINT, msgstate, severity C.int, msgt
 	}
 	msg += fmt.Sprintf("%s\n", C.GoString(msgtext))
 
-	lastMessageMutex.Lock()	
+	lastMessageMutex.Lock()
 	lastMessage = msg
 	lastMessageMutex.Unlock()
 

--- a/callbacks.go
+++ b/callbacks.go
@@ -2,6 +2,7 @@ package freetds
 
 import (
 	"fmt"
+	"sync"
 )
 
 /*
@@ -10,7 +11,11 @@ import (
 */
 import "C"
 
-var lastError, lastMessage string
+var lastError string
+var lastErrorMutex sync.Mutex
+
+var lastMessage string
+var lastMessageMutex sync.Mutex
 
 //export errHandler
 func errHandler(dbprocAddr C.long, severity, dberr, oserr C.int, dberrstr, oserrstr *C.char) C.int {
@@ -25,11 +30,15 @@ func errHandler(dbprocAddr C.long, severity, dberr, oserr C.int, dberrstr, oserr
 	}
 	err += fmt.Sprintf("\n%s\n\n", C.GoString(dberrstr))
 
+	lastErrorMutex.Lock()	
 	lastError = err
+	lastErrorMutex.Unlock()
+
 	conn := getConnection(int64(dbprocAddr))
 	if conn != nil {
 		conn.addError(err)
 	}
+
 	//fmt.Printf("err: %s", err)
 	return C.INT_CANCEL
 }
@@ -62,7 +71,10 @@ func msgHandler(dbprocAddr C.long, msgno C.DBINT, msgstate, severity C.int, msgt
 	}
 	msg += fmt.Sprintf("%s\n", C.GoString(msgtext))
 
+	lastMessageMutex.Lock()	
 	lastMessage = msg
+	lastMessageMutex.Unlock()
+
 	conn := getConnection(int64(dbprocAddr))
 	if conn != nil {
 		conn.addMessage(msg, int(msgno))

--- a/conn.go
+++ b/conn.go
@@ -136,7 +136,7 @@ func connectWithCredentials(crd *credentials) (*Conn, error) {
 		credentials:   *crd,
 		messageNums:   make(map[int]int),
 	}
-	err := conn.reconnect()
+	err := conn.Reconnect()
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func (conn *Conn) HasMessageNumber(msgno int) int {
 func (conn *Conn) Exec(sql string) ([]*Result, error) {
 	results, err := conn.exec(sql)
 	if err != nil && (conn.isDead() || conn.isMirrorSlave()) {
-		if err := conn.reconnect(); err != nil {
+		if err := conn.Reconnect(); err != nil {
 			return nil, err
 		}
 		results, err = conn.exec(sql)
@@ -277,7 +277,9 @@ func (conn *Conn) Exec(sql string) ([]*Result, error) {
 	return results, err
 }
 
-func (conn *Conn) reconnect() error {
+//Reconnect to the database, cleaning closing the existing connection
+//and switching to a Mirror Database if necessary.
+func (conn *Conn) Reconnect() error {
 	var err error
 	for i := 0; i < 2; i++ {
 		if conn.isMirrorMessage() {

--- a/conn.go
+++ b/conn.go
@@ -93,7 +93,9 @@ type Conn struct {
 	currentResult   *Result
 	expiresFromPool time.Time
 	belongsToPool   *ConnPool
-	spParamsCache   map[string][]*spParam
+
+	spParamsCache *ParamsCache
+
 	credentials
 	freetdsVersionGte095 bool
 }
@@ -132,7 +134,7 @@ func NewConn(connStr string) (*Conn, error) {
 
 func connectWithCredentials(crd *credentials) (*Conn, error) {
 	conn := &Conn{
-		spParamsCache: make(map[string][]*spParam),
+		spParamsCache: NewParamsCache(),
 		credentials:   *crd,
 		messageNums:   make(map[int]int),
 	}

--- a/conn.go
+++ b/conn.go
@@ -136,7 +136,7 @@ func connectWithCredentials(crd *credentials) (*Conn, error) {
 		credentials:   *crd,
 		messageNums:   make(map[int]int),
 	}
-	err := conn.Reconnect()
+	err := conn.reconnect()
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func (conn *Conn) HasMessageNumber(msgno int) int {
 func (conn *Conn) Exec(sql string) ([]*Result, error) {
 	results, err := conn.exec(sql)
 	if err != nil && (conn.isDead() || conn.isMirrorSlave()) {
-		if err := conn.Reconnect(); err != nil {
+		if err := conn.reconnect(); err != nil {
 			return nil, err
 		}
 		results, err = conn.exec(sql)
@@ -279,7 +279,7 @@ func (conn *Conn) Exec(sql string) ([]*Result, error) {
 
 //Reconnect to the database, cleaning closing the existing connection
 //and switching to a Mirror Database if necessary.
-func (conn *Conn) Reconnect() error {
+func (conn *Conn) reconnect() error {
 	var err error
 	for i := 0; i < 2; i++ {
 		if conn.isMirrorMessage() {

--- a/conn_pool.go
+++ b/conn_pool.go
@@ -35,7 +35,8 @@ type ConnPool struct {
 	poolMutex     sync.Mutex
 	cleanupTicker *time.Ticker
 	connCount     int
-	spParamsCache map[string][]*spParam
+
+	spParamsCache *ParamsCache
 }
 
 //NewCoonPool creates new connection pool.
@@ -56,7 +57,7 @@ func NewConnPool(connStr string) (*ConnPool, error) {
 		pool:          []*Conn{},
 		cleanupTicker: time.NewTicker(poolCleanupInterval),
 		connCount:     0,
-		spParamsCache: make(map[string][]*spParam),
+		spParamsCache: NewParamsCache(),
 	}
 	conn, err := p.newConn()
 	if err != nil {

--- a/conn_sp.go
+++ b/conn_sp.go
@@ -155,7 +155,7 @@ type spParam struct {
 //Read stored procedure parameters.
 //Will cache params in connection or pool and reuse it.
 func (conn *Conn) getSpParams(spName string) ([]*spParam, error) {
-	if spParams, ok := conn.spParamsCache[spName]; ok {
+	if spParams, ok := conn.spParamsCache.Get(spName); ok {
 		return spParams, nil
 	}
 
@@ -184,6 +184,6 @@ order by parameter_id
 		spParams[i] = p
 	}
 
-	conn.spParamsCache[spName] = spParams
+	conn.spParamsCache.Set(spName, spParams)
 	return spParams, nil
 }

--- a/conn_sp.go
+++ b/conn_sp.go
@@ -26,6 +26,12 @@ import "C"
 //Example:
 //  conn.ExecSp("sp_help", "authors")
 func (conn *Conn) ExecSp(spName string, params ...interface{}) (*SpResult, error) {
+	if conn.isDead() || conn.isMirrorSlave() {
+		if err := conn.reconnect(); err != nil {
+			return nil, err
+		}
+	}
+
 	//hold references to data sent to the C code until the end of this function
 	//without this GC could remove something used later in C, and we will get SIGSEG
 	refHolder := make([]*[]byte, 0)

--- a/conn_test.go
+++ b/conn_test.go
@@ -2,12 +2,12 @@ package freetds
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var CREATE_DB_SCRIPTS = [...]string{`
@@ -450,4 +450,33 @@ func TestExecuteSqlNullString(t *testing.T) {
 	var str *string
 	_, err := c.ExecuteSql("update dbo.freetds_types set nvarchar_max=? where int = 3", str)
 	assert.Nil(t, err)
+}
+
+// Also run with "go test --race" for race condition checking.
+func TestMessageNumbers(t *testing.T) {
+	const msgnumOne = 123
+	const msgnumTwo = 456
+
+	c := &Conn{
+		messageNums: make(map[int]int),
+	}
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		c.addMessage("alpha", msgnumOne)
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		c.addMessage("beta", msgnumOne)
+		c.addMessage("delta", msgnumTwo)
+		wg.Done()
+	}()
+
+	wg.Wait()
+	assert.Equal(t, c.HasMessageNumber(msgnumOne), 2)
+	assert.Equal(t, c.HasMessageNumber(msgnumTwo), 1)
 }

--- a/credentials.go
+++ b/credentials.go
@@ -7,7 +7,7 @@ import (
 
 type credentials struct {
 	user, pwd, host, database, mirrorHost, compatibility string
-	maxPoolSize, lockTimeout int
+	maxPoolSize, lockTimeout                             int
 }
 
 func NewCredentials(connStr string) *credentials {

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -31,16 +31,16 @@ func testCredentials(t *testing.T, crd *credentials) {
 }
 
 func TestParseConnectionStringCompatibilityMode(t *testing.T) {
-	setDefaultStrings := map[string]string {
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000": "",
+	setDefaultStrings := map[string]string{
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000":                           "",
 		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility_mode=Sybase": "sybase",
 		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility mode=sybase": "sybase",
 		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility Mode=sybase": "sybase",
 		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility_Mode=Sybase": "sybase",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility=Other": "other",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility=other": "other",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility=Other":       "other",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility=other":       "other",
 	}
-	for connStr,expected := range setDefaultStrings {
+	for connStr, expected := range setDefaultStrings {
 		crd := NewCredentials(connStr)
 		assert.NotNil(t, crd)
 		assert.Equal(t, "myServerAddress", crd.host)

--- a/params_cache.go
+++ b/params_cache.go
@@ -1,0 +1,29 @@
+package freetds
+
+import (
+	"sync"
+)
+
+type ParamsCache struct {
+	cache map[string][]*spParam
+	sync.RWMutex
+}
+
+func (pc *ParamsCache) Get(spName string) ([]*spParam, bool) {
+	pc.RLock()
+	defer pc.RUnlock()
+	params, found := pc.cache[spName]
+	return params, found
+}
+
+func (pc *ParamsCache) Set(spName string, params []*spParam) {
+	pc.Lock()
+	pc.cache[spName] = params
+	pc.Unlock()
+}
+
+func NewParamsCache() *ParamsCache {
+	return &ParamsCache{
+		cache: make(map[string][]*spParam),
+	}
+}


### PR DESCRIPTION
I have a need to intercept certain FreeTDS Message Numbers in my daemon, and if they occur act upon them (specifically, delay and then retry if I get 1204 or 1205).

This pull request adds a map to count occurrences of Message Numbers as they are reported and a function to get the count of a specific Message Number.
I've also added a necessary mutex which is required to pass "go test --race"

I've also made the Conn.reconnect() function public, so I can reconnect before retrying my procedure call. I could not see another way to do this when using a pooled connection as you cannot actually close a pooled connection, only return it to the pool.

"go fmt" has also been run.

This addresses issue #36 