### PR TITLE
Add support for column type 241 (XML)

### DIFF
--- a/convert_sql_buf.go
+++ b/convert_sql_buf.go
@@ -22,6 +22,7 @@ const (
 	SYBNVARCHAR  = 103 //nvarchar      string
 	XSYBNVARCHAR = 231 //nvarchar      string
 	XSYBNCHAR    = 239 //nchar         string
+	XSYBXML      = 241 //XML           string
 
 	SYBREAL = 59 //real          float32
 	SYBFLT8 = 62 //float(53)     float64

--- a/fetch.go
+++ b/fetch.go
@@ -40,12 +40,13 @@ func (conn *Conn) fetchResults() ([]*Result, error) {
 			}
 			bindTyp, typ := dbbindtype(typ)
 			result.addColumn(name, int(size), int(typ))
-			if bindTyp == C.NTBSTRINGBIND && C.SYBCHAR != typ && C.SYBTEXT != typ {
+			if bindTyp == C.NTBSTRINGBIND && C.SYBCHAR != typ && C.SYBTEXT != typ && XSYBXML != typ {
 				size = C.DBINT(C.dbwillconvert(typ, C.SYBCHAR))
 			}
 			col := &columns[i]
 			// detecting varchar(max) or varbinary(max) types
 			col.canVary = (size == 2147483647 && typ == SYBCHAR) ||
+				(size == 2147483647 && typ == XSYBXML) ||
 				(size == 1073741823 && typ == SYBBINARY)
 			col.name = name
 			col.typ = int(typ)


### PR DESCRIPTION
fixes error when reading XML column type:
dbbind failed: no such column or no such conversion possible, or target buffer too small.

---

Fixes issue #39.
My quick test for this passed and I am now able to read XML columns with no problem. But I didn't have time to write tests for this, because I don't have SQL Server available on which I could run the tests.
