### PR TITLE
Set database name in connection string as part of login packet

### DIFF
--- a/conn_sp_test.go
+++ b/conn_sp_test.go
@@ -344,7 +344,7 @@ func TestNewDateTypesParam(t *testing.T) {
 	var dt time.Time
 	err = rst.Scan(&dt, &op1, &op2, &op3, &op4)
 	assert.Nil(t, err)
-	assert.Equal(t, "2025-12-10T12:32:10+01:00", dt.Format(time.RFC3339))
+	assert.Equal(t, "Wed Dec 10 12:32:10 2025", dt.Format(time.ANSIC)) //ANSIC format makes test independent of the time zone in which the test is run
 	assert.Equal(t, "2025-12-10 12:32:10.1237000 +01:00", op1)
 	assert.Equal(t, "2025-12-10", op2)
 	assert.Equal(t, "12:30:00.0000000", op3)

--- a/conn_test.go
+++ b/conn_test.go
@@ -19,12 +19,12 @@ create table freetds_types (
   long bigint null,
   smallint smallint null,
   tinyint tinyint null,
-  varchar varchar(255) null,
-  nvarchar nvarchar(255) null,
-  char char(255) null,
-  nchar nchar(255) null,
-  text text null,
-  ntext ntext null,
+  varchar varchar(255) COLLATE latin1_general_ci_as null ,
+  nvarchar nvarchar(255) COLLATE latin1_general_ci_as null,
+  char char(255) COLLATE latin1_general_ci_as null,
+  nchar nchar(255) COLLATE latin1_general_ci_as null,
+  text text COLLATE latin1_general_ci_as null,
+  ntext ntext COLLATE latin1_general_ci_as null,
   datetime datetime null,
   smalldatetime smalldatetime null,
   money money null,
@@ -34,17 +34,17 @@ create table freetds_types (
   bit bit null,
   timestamp timestamp null,
   binary binary(10) null,
-  nvarchar_max nvarchar(max) null,
-  varchar_max varchar(max) null,
+  nvarchar_max nvarchar(max) COLLATE latin1_general_ci_as null,
+  varchar_max varchar(max) COLLATE latin1_general_ci_as null,
   varbinary_max varbinary(max) null
 )
 ;
 
 insert into freetds_types (int, long, smallint, tinyint, varchar, nvarchar, char, nchar, text, ntext, datetime, smalldatetime, money, smallmoney, real, float, bit, binary)
-values (2147483647,   9223372036854775807, 32767, 255, 'išo medo u dućan   ','išo medo u dućan    2','išo medo u dućan    3','išo medo u dućan    4','išo medo u dućan    5','išo medo u dućan    6', '1972-08-08T10:11:12','1972-08-08T10:11:12', 1234.5678,   1234.5678,  1234.5678,  1234.5678, 0, 0x123567890)
+values (2147483647,   9223372036854775807, 32767, 255, 'išo medo u dućan   ',N'išo medo u dućan    2','išo medo u dućan    3',N'išo medo u dućan    4','išo medo u dućan    5',N'išo medo u dućan    6', '1972-08-08T10:11:12','1972-08-08T10:11:12', 1234.5678,   1234.5678,  1234.5678,  1234.5678, 0, 0x123567890)
 
 insert into freetds_types (int, long, smallint, tinyint, varchar, nvarchar, char, nchar, text, ntext, datetime, smalldatetime, money, smallmoney, real, float, bit, binary)
-values (-2147483648, -9223372036854775808, -32768,  0, 'nije reko dobar dan','nije reko dobar dan 2','nije reko dobar dan 3','nije reko dobar dan 4','nije reko dobar dan 5','nije reko dobar dan 6', '1998-10-10T16:17:18','1998-10-10T16:17:18', -1234.5678, -1234.5678, -1234.5678, -1234.5678, 1, 0x0987654321abcd)
+values (-2147483648, -9223372036854775808, -32768,  0, 'nije reko dobar dan',N'nije reko dobar dan 2','nije reko dobar dan 3',N'nije reko dobar dan 4','nije reko dobar dan 5',N'nije reko dobar dan 6', '1998-10-10T16:17:18','1998-10-10T16:17:18', -1234.5678, -1234.5678, -1234.5678, -1234.5678, 1, 0x0987654321abcd)
 
 insert into freetds_types (int) values (3)
 `, `
@@ -134,7 +134,7 @@ func TestReadingTextNtext(t *testing.T) {
 	defer conn.Close()
 	results, err := conn.Exec(`select top 2 text, ntext from dbo.freetds_types`)
 	assert.Nil(t, err)
-	assert.Equal(t, "išo medo u dućan    5", results[0].Rows[0][0])
+	assert.Equal(t, "išo medo u ducan    5", results[0].Rows[0][0])
 	assert.Equal(t, "išo medo u dućan    6", results[0].Rows[0][1])
 	assert.Equal(t, "nije reko dobar dan 5", results[0].Rows[1][0])
 	assert.Equal(t, "nije reko dobar dan 6", results[0].Rows[1][1])

--- a/executesql_test.go
+++ b/executesql_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const(
+	sqlDateTimeOffSet = "2006-01-02T15:04:05-07:00"
+)
+
 func TestGoTo2SqlDataType2(t *testing.T) {
 	var checker = func(value interface{}, sqlType string, sqlFormatedValue string) {
 		actualSqlType, actualSqlFormatedValue := go2SqlDataType(value)
@@ -25,7 +29,9 @@ func TestGoTo2SqlDataType2(t *testing.T) {
 	checker("iso medo isn't", "nvarchar (14)", "'iso medo isn''t'")
 
 	tm := time.Unix(1136239445, 0)
-	checker(tm, "datetimeoffset", "'2006-01-02T23:04:05+01:00'")
+	paris, _ := time.LoadLocation("Europe/Paris")
+
+	checker(tm.In(paris), "datetimeoffset", "'" + tm.In(paris).Format(sqlDateTimeOffSet) +"'")
 
 	checker([]byte{1, 2, 3, 4, 5, 6, 7, 8}, "varbinary (8)", "0x0102030405060708")
 
@@ -67,7 +73,9 @@ func TestGoTo2SqlDataType(t *testing.T) {
 	checker("iso medo isn't", "nvarchar (14)", "'iso medo isn''t'")
 
 	tm := time.Unix(1136239445, 0)
-	checker(tm, "datetimeoffset", "'2006-01-02T23:04:05+01:00'")
+	paris, _ := time.LoadLocation("Europe/Paris")
+
+	checker(tm.In(paris), "datetimeoffset", "'" + tm.In(paris).Format(sqlDateTimeOffSet) +"'")
 
 	checker([]byte{1, 2, 3, 4, 5, 6, 7, 8}, "varbinary (8)", "0x0102030405060708")
 


### PR DESCRIPTION
The conn.go `connect` method used `DbUse` to switch into the database name specified in the connection string, which behind the scenes issues a `USE <dbname>` command.
This prevented `gofreetds` being used with Azure SQL Database, which doesn't support the `USE` command - the database name must be specified in the login packet.
FreeTDS has supported this behaviour since 0.91. This PR alters conn.go to set the database name in the login packet.

I also had a few problems running the tests; I have made a number of changes to make the tests less dependent on the configuration and time zone of the SQL Server where the tests are being run.