### PR TITLE
Support Scan for single column by it's name

### DIFF
--- a/result.go
+++ b/result.go
@@ -43,13 +43,6 @@ func (r *Result) addValue(row, col int, value interface{}) {
 	r.Rows[row][col] = value
 }
 
-type ResultColumn struct {
-	Name   string
-	DbSize int
-	DbType int
-	Type   string
-}
-
 func (r *Result) Next() bool {
 	if len(r.Rows) == 0 {
 		return false

--- a/result.go
+++ b/result.go
@@ -43,11 +43,23 @@ func (r *Result) addValue(row, col int, value interface{}) {
 	r.Rows[row][col] = value
 }
 
-func (r *Result) Next() bool {
+// CurrentRow() returns current row (set by Next()).
+// Returns -1 as an error if Next() wasn't called.
+func (r *Result) CurrentRow() int {
+	return r.currentRow
+}
+
+// HasNext returns true if we have more rows to process.
+func (r *Result) HasNext() bool {
 	if len(r.Rows) == 0 {
 		return false
 	}
-	if r.currentRow >= len(r.Rows)-1 {
+	return r.currentRow < len(r.Rows)-1
+}
+
+// Advances to the next row. Returns false if there is no more rows (i.e. we are on the last row).
+func (r *Result) Next() bool {
+	if !r.HasNext() {
 		return false
 	}
 	r.currentRow++

--- a/result_column.go
+++ b/result_column.go
@@ -1,0 +1,8 @@
+package freetds
+
+type ResultColumn struct {
+	Name   string
+	DbSize int
+	DbType int
+	Type   string
+}

--- a/result_test.go
+++ b/result_test.go
@@ -92,7 +92,7 @@ func TestResultScanWithoutNext(t *testing.T) {
 	var tm time.Time
 	var f float64
 	err := r.Scan(&i, &s, &tm, &f)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestResultScanOnNonPointerValues(t *testing.T) {
@@ -103,7 +103,7 @@ func TestResultScanOnNonPointerValues(t *testing.T) {
 	var f float64
 	assert.True(t, r.Next())
 	err := r.Scan(&i, &s, &tm, f)
-	assert.NotNil(t, err) //error is raised
+	assert.Error(t, err)
 }
 
 func TestResultScanIntoStruct(t *testing.T) {
@@ -126,7 +126,7 @@ func TestResultScanIntoStruct(t *testing.T) {
 	err = r.MustScan(4, &s)
 	assert.Nil(t, err)
 	err = r.MustScan(5, &s)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestScanTypesInStructDoesNotMatchThoseInResult(t *testing.T) {
@@ -151,4 +151,36 @@ func TestScanTypesInStructDoesNotMatchThoseInResult(t *testing.T) {
 
 	assert.Equal(t, s.Float32, 5.5)
 	assert.EqualValues(t, s.Float64, 6.5)
+}
+
+func TestResultScanColumn(t *testing.T) {
+	r := testResult()
+	assert.True(t, r.Next())
+	var s string
+	err := r.ScanColumn("s", &s)
+	assert.Nil(t, err)
+	assert.Equal(t, "two", s)
+}
+
+func TestResultScanColumnWithoutNext(t *testing.T) {
+	r := testResult()
+	var s string
+	err := r.ScanColumn("s", &s)
+	assert.Error(t, err)
+}
+
+func TestResultScanColumnOnNonPointerValues(t *testing.T) {
+	r := testResult()
+	assert.True(t, r.Next())
+	var s string
+	err := r.ScanColumn("s", s)
+	assert.Error(t, err)
+}
+
+func TestResultScanColumnMissing(t *testing.T) {
+	r := testResult()
+	assert.True(t, r.Next())
+	var s string
+	err := r.ScanColumn("non_existing", &s)
+	assert.Error(t, err)
 }

--- a/result_test.go
+++ b/result_test.go
@@ -57,6 +57,25 @@ func TestResultScan(t *testing.T) {
 	assert.Equal(t, f, float64(123.45))
 }
 
+func TestResultCurrentRow(t *testing.T) {
+	r := testResult()
+	assert.Equal(t, -1, r.CurrentRow())
+	assert.True(t, r.Next())
+	assert.Equal(t, 0, r.CurrentRow())
+}
+
+func TestResultHasNext(t *testing.T) {
+	r := testResult()
+	assert.Equal(t, len(r.Rows), 3)
+	assert.True(t, r.Next())
+	assert.True(t, r.HasNext())
+	assert.True(t, r.Next())
+	assert.True(t, r.HasNext())
+	assert.True(t, r.Next())
+	assert.False(t, r.Next())
+	assert.False(t, r.HasNext())
+}
+
 func TestResultNext(t *testing.T) {
 	r := testResult()
 	assert.Equal(t, len(r.Rows), 3)


### PR DESCRIPTION
Used for cases where you don't exactly know what fields will be returned (maybe the DBA adds new columns in the middle, or someone changes single table which affects tens of views/procedures).

Scan to struct should solve that too, but Scan with struct has a limitation in that the column name must begin with upper case (because exports...) and cannot contain spaces and other common problems.

Other DB adapters try to use tags for those cases, but we don't have support for that and this was way simpler. And it uses less magic.

Usage (as can be seen in tests):

```go
                var s string
		err = r.ScanColumn("some_column", &s)
		if err != nil {
			return err
		}
```

P.S. I am little worried about performance of this. As you can see in result.go in new method FindColumn, there is a TODO for using hash map as a cache of column name to it's array index in r.Columns. But I tried that and it was 2 times slower than simple array seq scan, so the TODO is now obsolete.

What do you think?

P.P.S. Also, add CurrentRow() helper method for those guys who actually want to know what row we are on. With that, people can implement your own Row parsing and can use Next() at the same time. (Without CurrentRow, we would need to use `for i, row := range r.Rows` ...)