### PR TITLE
Fix issue when data-type conversion error leaves connection unusable for stored procedure calls

### DIFF
--- a/conn_sp.go
+++ b/conn_sp.go
@@ -57,6 +57,7 @@ func (conn *Conn) ExecSp(spName string, params ...interface{}) (*SpResult, error
 			if param != nil {
 				data, sqlDatalen, err := typeToSqlBuf(int(spParam.UserTypeId), param, conn.freetdsVersionGte095)
 				if err != nil {
+					conn.Close() //close the connection
 					return nil, err
 				}
 				if len(data) > 0 {

--- a/conn_sp_test.go
+++ b/conn_sp_test.go
@@ -408,3 +408,34 @@ func TestBugFixVarchar(t *testing.T) {
 	_, err = conn.ExecSp("test_bug_fix_varchar", str)
 	assert.Nil(t, err)
 }
+
+func TestExecSpBadParameterDataType(t *testing.T) {
+	conn := ConnectToTestDb(t)
+	err := createProcedure(conn, "test_bad_parameter_data_type", ` 
+	@p1 varchar(20)
+	as
+	select @p1
+	return`)
+	assert.Nil(t, err)
+	
+	err = createProcedure(conn, "test_bad_parameter_data_type2", " as select 1 one; select 2 two; return 456")
+	assert.Nil(t, err)
+
+	
+	var intval int16
+	intval = 1
+	_, err = conn.ExecSp("test_bad_parameter_data_type", intval)
+	expectedError := "Could not convert int16 to string."
+	assert.Equal(t, expectedError, err.Error())
+	
+	_, err = conn.ExecSp("test_bad_parameter_data_type", "test")
+	assert.Nil(t, err)	
+
+	_, err = conn.ExecSp("test_bad_parameter_data_type2")
+	assert.Nil(t, err)	
+	
+}
+
+
+
+


### PR DESCRIPTION
If a data-type conversion occurred when stored procedure parameter values were being mapped, the connection was left in a state where it could not be used for further stored procedure calls:
 - A dbrpcinit error occurred if the same procedure was called
 - A 20019 error occurred if a different procedure was called
This change resolves this problem by closing the connection if a parameter mapping error occurs.