### PR TITLE
Fix to #50 - Call Conn.close() and prevent it being reused if pooled.

### DIFF
--- a/conn_sp.go
+++ b/conn_sp.go
@@ -49,7 +49,7 @@ func (conn *Conn) ExecSp(spName string, params ...interface{}) (*SpResult, error
 		return nil, err
 	}
 	for i, spParam := range spParams {
-		//get datavalue for the suplied stored procedure parametar
+		//get datavalue for the suplied stored procedure parameter
 		var datavalue *C.BYTE
 		datalen := 0
 		if i < len(params) {
@@ -57,7 +57,7 @@ func (conn *Conn) ExecSp(spName string, params ...interface{}) (*SpResult, error
 			if param != nil {
 				data, sqlDatalen, err := typeToSqlBuf(int(spParam.UserTypeId), param, conn.freetdsVersionGte095)
 				if err != nil {
-					conn.Close() //close the connection
+					conn.close() //hard close the connection, if pooled don't return it.
 					return nil, err
 				}
 				if len(data) > 0 {

--- a/conn_sp_test.go
+++ b/conn_sp_test.go
@@ -417,25 +417,20 @@ func TestExecSpBadParameterDataType(t *testing.T) {
 	select @p1
 	return`)
 	assert.Nil(t, err)
-	
+
 	err = createProcedure(conn, "test_bad_parameter_data_type2", " as select 1 one; select 2 two; return 456")
 	assert.Nil(t, err)
 
-	
 	var intval int16
 	intval = 1
 	_, err = conn.ExecSp("test_bad_parameter_data_type", intval)
 	expectedError := "Could not convert int16 to string."
 	assert.Equal(t, expectedError, err.Error())
-	
+
 	_, err = conn.ExecSp("test_bad_parameter_data_type", "test")
-	assert.Nil(t, err)	
+	assert.Nil(t, err)
 
 	_, err = conn.ExecSp("test_bad_parameter_data_type2")
-	assert.Nil(t, err)	
-	
+	assert.Nil(t, err)
+
 }
-
-
-
-


### PR DESCRIPTION
The fix made #50 used Conn.Close() which worked fine for non-pooled connections, but was not closing pooled connections and so returning unusable connections to the pool.
This fix applies uses conn.close() which closes the connection regardless of if it's in a pool or not.
If the connection was pooled then the pool will create a new connection to replace it.
I also ran go fmt.
All unit tests pass.