### PR TITLE
Unpool Connections and Error Number Lookup

### DIFF
--- a/callbacks.go
+++ b/callbacks.go
@@ -36,7 +36,7 @@ func errHandler(dbprocAddr C.long, severity, dberr, oserr C.int, dberrstr, oserr
 
 	conn := getConnection(int64(dbprocAddr))
 	if conn != nil {
-		conn.addError(err)
+		conn.addError(err, int(dberr))
 	}
 
 	//fmt.Printf("err: %s", err)

--- a/conn.go
+++ b/conn.go
@@ -277,15 +277,14 @@ func (conn *Conn) DbUse() error {
 
 func (conn *Conn) clearMessages() {
 	conn.messageMutex.Lock()
-	conn.errorsMutex.Lock()
-
 	conn.Error = ""
 	conn.errors = make(map[int]string)
-	conn.Message = ""
-	conn.messageNums = make(map[int]int)
+	conn.messageMutex.Unlock()
 
 	conn.errorsMutex.Lock()
-	conn.messageMutex.Unlock()
+	conn.Message = ""
+	conn.messageNums = make(map[int]int)
+	conn.errorsMutex.Unlock()
 }
 
 //Returns the number of occurances of a supplied FreeTDS message number.

--- a/conn.go
+++ b/conn.go
@@ -198,7 +198,7 @@ func (conn *Conn) close() {
 }
 
 // Remove a pooled connection from it's pool.
-func RemoveFromPool(conn *Conn) *Conn {
+func (conn *Conn) RemoveFromPool() *Conn {
 	if conn.belongsToPool != nil {
 		conn.belongsToPool.Remove(conn)
 	}

--- a/conn_pool.go
+++ b/conn_pool.go
@@ -162,6 +162,17 @@ func (p *ConnPool) addToPool(conn *Conn) {
 	}
 }
 
+// Remove a pooled connection from the pool,
+// forcing a new connection to take it's place.
+func (p *ConnPool) Remove(conn *Conn) {
+	if conn.belongsToPool != p {
+		return
+	}
+	p.connCount--
+	<-p.poolGuard //remove reservation
+	conn.belongsToPool = nil
+}
+
 //Release connection to the pool.
 func (p *ConnPool) Release(conn *Conn) {
 	if conn.belongsToPool != p {

--- a/conn_sp.go
+++ b/conn_sp.go
@@ -49,7 +49,7 @@ func (conn *Conn) ExecSp(spName string, params ...interface{}) (*SpResult, error
 		return nil, err
 	}
 	for i, spParam := range spParams {
-		//get datavalue for the suplied stored procedure parametar
+		//get datavalue for the suplied stored procedure parameter
 		var datavalue *C.BYTE
 		datalen := 0
 		if i < len(params) {
@@ -57,7 +57,7 @@ func (conn *Conn) ExecSp(spName string, params ...interface{}) (*SpResult, error
 			if param != nil {
 				data, sqlDatalen, err := typeToSqlBuf(int(spParam.UserTypeId), param, conn.freetdsVersionGte095)
 				if err != nil {
-					conn.Close() //close the connection
+					conn.close() //hard close the connection, if pooled don't return it.
 					return nil, err
 				}
 				if len(data) > 0 {

--- a/conn_sp_test.go
+++ b/conn_sp_test.go
@@ -417,25 +417,20 @@ func TestExecSpBadParameterDataType(t *testing.T) {
 	select @p1
 	return`)
 	assert.Nil(t, err)
-	
+
 	err = createProcedure(conn, "test_bad_parameter_data_type2", " as select 1 one; select 2 two; return 456")
 	assert.Nil(t, err)
 
-	
 	var intval int16
 	intval = 1
 	_, err = conn.ExecSp("test_bad_parameter_data_type", intval)
 	expectedError := "Could not convert int16 to string."
 	assert.Equal(t, expectedError, err.Error())
-	
+
 	_, err = conn.ExecSp("test_bad_parameter_data_type", "test")
-	assert.Nil(t, err)	
+	assert.Nil(t, err)
 
 	_, err = conn.ExecSp("test_bad_parameter_data_type2")
-	assert.Nil(t, err)	
-	
+	assert.Nil(t, err)
+
 }
-
-
-
-


### PR DESCRIPTION
Due to VPN issues in our production environment I have a quality of service requirement to inspect the FreeTDS error numbers which might have occurred on a Connection and if certain errors have occurred, then ensure that the connection is not re-used (not returned to the connection pool).

To support error number lookup efficiently I have added function HasErrorNumber, which provides a goroutine safe (mutex controlled) map of FreeTDS error numbers and their assigned string. This is very similar to the Conn.HasMessageNumber functionality I have added previously.

To support not releasing connections back into the pool, two new functions have been added:
1. Conn.RemoveFromPool() will remove the connection from the pool and return it.
This allows the user to write calls such as: c1.RemoveFromPool().Close()
It also means that the function making the call doesn't need access to the actual pool object as well.

2. ConnPool.Remove() will remove the supplied Conn from the Pool.

Both functions are safe to call repeatably and if the conn is not actually in the pool.  
Additional unit tests have been added to cover the new functionality.
They can be run with --race to prove goroutine safety:
go test --race

All existing unit tests pass.