### PR TITLE
When scanning into a single value, check if that value is a time and return nil from asStructPointer if it is.

### DIFF
--- a/result.go
+++ b/result.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 )
 
 type Result struct {
@@ -156,7 +157,9 @@ func (r *Result) scanStruct(s *reflect.Value) error {
 
 func asStructPointer(p interface{}) *reflect.Value {
 	sp := reflect.ValueOf(p)
-	if sp.Kind() == reflect.Ptr {
+	if _, ok := p.(*time.Time); ok {
+		return nil
+	} else if sp.Kind() == reflect.Ptr {
 		s := sp.Elem()
 		if s.Kind() == reflect.Struct {
 			return &s

--- a/result_test.go
+++ b/result_test.go
@@ -57,6 +57,17 @@ func TestResultScan(t *testing.T) {
 	assert.Equal(t, f, float64(123.45))
 }
 
+func TestResultScanSingleTime(t *testing.T) {
+	var tm time.Time
+	r := NewResult()
+	r.addColumn("tm", 0, 0)
+	r.addValue(0, 0, now)
+	assert.True(t, r.Next())
+	err := r.Scan(&tm)
+	assert.Nil(t, err)
+	assert.Equal(t, tm, now)
+}
+
 func TestResultCurrentRow(t *testing.T) {
 	r := testResult()
 	assert.Equal(t, -1, r.CurrentRow())


### PR DESCRIPTION
This solves an issue caused when selecting a single time, and calling
scan with a single time. Since a time is technically a struct,
asStructPointer will not return nil, causing us to call scanStruct on
the time.

All unit tests pass. 