### PR TITLE
Handling allowances for Sybase ASE 12.5

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -83,6 +83,7 @@ func deleteConnection(conn *Conn) {
 }
 
 const SYBASE string = "sybase"
+const SYBASE_12_5 string = "sybase_12_5"
 
 //Connection to the database.
 type Conn struct {
@@ -221,7 +222,7 @@ func (conn *Conn) getDbProc() (*C.DBPROCESS, error) {
 	// Added for Sybase compatibility mode
 	// Version cannot be set to 7.2
 	// Allowing version to be set inside freetds
-	if conn.credentials.compatibility != SYBASE {
+	if conn.credentials.compatibility != SYBASE && conn.credentials.compatibility != SYBASE_12_5{
 		C.my_setlversion(login)
 	}
 
@@ -428,7 +429,7 @@ func (conn *Conn) setDefaults() error {
 	// Adding check for Sybase compatiblity mode
 	// These connection settings below do not
 	// function with Sybase ASE
-	if conn.credentials.compatibility != SYBASE {
+	if conn.credentials.compatibility != SYBASE && conn.credentials.compatibility != SYBASE_12_5 {
 		//defaults copied from .Net Driver
 		_, err = conn.exec(`
         set quoted_identifier on

--- a/conn.go
+++ b/conn.go
@@ -222,7 +222,7 @@ func (conn *Conn) getDbProc() (*C.DBPROCESS, error) {
 	// Added for Sybase compatibility mode
 	// Version cannot be set to 7.2
 	// Allowing version to be set inside freetds
-	if conn.credentials.compatibility != SYBASE && conn.credentials.compatibility != SYBASE_12_5{
+	if !conn.sybaseMode() && !conn.sybaseMode125() {
 		C.my_setlversion(login)
 	}
 
@@ -429,7 +429,7 @@ func (conn *Conn) setDefaults() error {
 	// Adding check for Sybase compatiblity mode
 	// These connection settings below do not
 	// function with Sybase ASE
-	if conn.credentials.compatibility != SYBASE && conn.credentials.compatibility != SYBASE_12_5 {
+	if !conn.sybaseMode() && !conn.sybaseMode125() {
 		//defaults copied from .Net Driver
 		_, err = conn.exec(`
         set quoted_identifier on
@@ -442,7 +442,11 @@ func (conn *Conn) setDefaults() error {
 		}
 	}
 	if t := conn.credentials.lockTimeout; t > 0 {
-		_, err = conn.exec(fmt.Sprintf("set lock_timeout %d", t))
+		sql := "set lock_timeout %d"
+		if conn.sybaseMode125() {
+			sql = "set lock wait %d"
+		}
+		_, err = conn.exec(fmt.Sprintf(sql, t))
 	}
 	return err
 }
@@ -473,4 +477,12 @@ func parseFreeTdsVersion(dbVersion string) []int {
 		}
 	}
 	return freeTdsVersion
+}
+
+func (conn Conn) sybaseMode() bool {
+	return conn.credentials.compatibility == SYBASE
+}
+
+func (conn Conn) sybaseMode125() bool {
+	return conn.credentials.compatibility == SYBASE_12_5
 }

--- a/conn_sp.go
+++ b/conn_sp.go
@@ -210,7 +210,7 @@ const sybaseAseGetSpParamsSql string = `
 `
 
 func (conn *Conn) getSpParamsSql(spName string) string {
-	if conn.credentials.compatibility == SYBASE {
+	if conn.credentials.compatibility == SYBASE || conn.credentials.compatibility == SYBASE_12_5 {
 		return fmt.Sprintf(sybaseAseGetSpParamsSql, spName)
 	}
 	return fmt.Sprintf(msSqlGetSpParamsSql, spName)

--- a/conn_sp.go
+++ b/conn_sp.go
@@ -206,11 +206,11 @@ const sybaseAseGetSpParamsSql string = `
          join syscolumns c
            on c.id = o.id
   where o.name = '%s'
-  order by c.id
+  order by c.id, c.colid
 `
 
 func (conn *Conn) getSpParamsSql(spName string) string {
-	if conn.credentials.compatibility == SYBASE || conn.credentials.compatibility == SYBASE_12_5 {
+	if conn.sybaseMode() || conn.sybaseMode125() {
 		return fmt.Sprintf(sybaseAseGetSpParamsSql, spName)
 	}
 	return fmt.Sprintf(msSqlGetSpParamsSql, spName)

--- a/conn_test.go
+++ b/conn_test.go
@@ -15,7 +15,7 @@ import (
 var CREATE_DB_SCRIPTS = [...]string{`
 if exists(select * from sys.tables where name = 'freetds_types')
 drop table freetds_types
-;
+`, `
 create table freetds_types (
   int int null,
   long bigint null,
@@ -58,10 +58,63 @@ create procedure freetds_return_value as
 	`
 if exists(select * from sys.tables where name = 'tm')
 drop table tm
-;
+`, `
 create table [dbo].[tm] (
 	[id] int NOT NULL IDENTITY(1, 1),
 	[tm] datetime null
+)`,
+}
+
+var CREATE_DB_SCRIPTS_SYBASE_12_5 = [...]string{`
+if exists(select name from sysobjects where name = 'freetds_types')
+drop table freetds_types
+`, `
+create table freetds_types (
+  int int null,
+  long decimal(19,0) null,
+  smallint smallint null,
+  tinyint tinyint null,
+  varchar varchar(255) null ,
+  nvarchar nvarchar(255) null,
+  char char(255) null,
+  nchar nchar(255) null,
+  text text null,
+  ntext text null,
+  datetime datetime null,
+  smalldatetime smalldatetime null,
+  money money null,
+  smallmoney smallmoney null,
+  real real null,
+  float float(48) null,
+  bit bit,
+  timestamp timestamp null,
+  binary binary(10) null,
+  nvarchar_max text null,
+  varchar_max text null,
+  varbinary_max image null
+)
+
+
+insert into freetds_types (int, long, smallint, tinyint, varchar, nvarchar, char, nchar, text, ntext, datetime, smalldatetime, money, smallmoney, real, float, bit, binary)
+values (2147483647,   9223372036854775807, 32767, 255, 'išo medo u dućan   ',N'išo medo u dućan    2','išo medo u dućan    3',N'išo medo u dućan    4','išo medo u dućan    5',N'išo medo u dućan    6', '1972-08-08 10:11:12','1972-08-08 10:11:12', 1234.5678,   1234.5678,  1234.5678,  1234.5678, 0, 0x123567890)
+
+insert into freetds_types (int, long, smallint, tinyint, varchar, nvarchar, char, nchar, text, ntext, datetime, smalldatetime, money, smallmoney, real, float, bit, binary)
+values (-2147483648, -9223372036854775808, -32768,  0, 'nije reko dobar dan',N'nije reko dobar dan 2','nije reko dobar dan 3',N'nije reko dobar dan 4','nije reko dobar dan 5',N'nije reko dobar dan 6', '1998-10-10 16:17:18','1998-10-10 16:17:18', -1234.5678, -1234.5678, -1234.5678, -1234.5678, 1, 0x0987654321abcd)
+
+insert into freetds_types (int, bit) values (3, 0)
+`, `
+if exists(select name from sysobjects where name='freetds_return_value' and type='P')
+  drop procedure freetds_return_value
+`, `
+create procedure freetds_return_value as
+  return -5`,
+	`
+if exists(select name from sysobjects where name='tm' and type='U')
+drop table tm
+`, `
+create table tm (
+	id int IDENTITY NOT NULL ,
+	tm datetime null
 )`,
 }
 
@@ -82,7 +135,12 @@ func runCreateDBScripts() error {
 	}
 	defer conn.Close()
 
-	for _, s := range CREATE_DB_SCRIPTS {
+	scripts := CREATE_DB_SCRIPTS
+	if conn.sybaseMode125() {
+		scripts = CREATE_DB_SCRIPTS_SYBASE_12_5
+	}
+
+	for _, s := range scripts {
 		_, err := conn.Exec(s)
 		if err != nil {
 			return fmt.Errorf("Error running create db scripts with sql: %v\n%v", s, err)
@@ -101,6 +159,25 @@ func ConnectToTestDb(t *testing.T) *Conn {
 	return conn
 }
 
+func ConnectToTestDbSybase(t *testing.T) *Conn {
+	conn, err := NewConn(testDbConnStrSybase(1))
+	if err != nil {
+		t.Errorf("can't connect to the test database")
+		return nil
+	}
+	return conn
+}
+
+func ConnectToTestDbSybase125(t *testing.T) *Conn {
+	conn, err := NewConn(testDbConnStrSybase125(1))
+	if err != nil {
+		t.Errorf("can't connect to the test database")
+		return nil
+	}
+	return conn
+}
+
+
 func testDbConnStr(maxPoolSize int) string {
 	connStr := os.Getenv("GOFREETDS_CONN_STR")
 	mirror := os.Getenv("GOFREETDS_MIRROR_HOST")
@@ -108,6 +185,26 @@ func testDbConnStr(maxPoolSize int) string {
 		connStr = fmt.Sprintf("%s;mirror=%s", connStr, mirror)
 	}
 	connStr = fmt.Sprintf("%s;max_pool_size=%d", connStr, maxPoolSize)
+	return connStr
+}
+
+func testDbConnStrSybase(maxPoolSize int) string {
+	connStr := os.Getenv("GOFREETDS_CONN_STR")
+	mirror := os.Getenv("GOFREETDS_MIRROR_HOST")
+	if mirror != "" {
+		connStr = fmt.Sprintf("%s;mirror=%s;compatibility=sybase", connStr, mirror)
+	}
+	connStr = fmt.Sprintf("%s;max_pool_size=%d;compatibility=sybase", connStr, maxPoolSize)
+	return connStr
+}
+
+func testDbConnStrSybase125(maxPoolSize int) string {
+	connStr := os.Getenv("GOFREETDS_CONN_STR")
+	mirror := os.Getenv("GOFREETDS_MIRROR_HOST")
+	if mirror != "" {
+		connStr = fmt.Sprintf("%s;mirror=%s;compatibility=sybase_12_5", connStr, mirror)
+	}
+	connStr = fmt.Sprintf("%s;max_pool_size=%d;compatibility=sybase_12_5", connStr, maxPoolSize)
 	return connStr
 }
 
@@ -121,6 +218,26 @@ func TestConnect(t *testing.T) {
 	defer conn.Close()
 	assert.True(t, conn.isLive())
 	assert.False(t, conn.isDead())
+}
+
+func TestConnectSybase(t *testing.T) {
+	conn := ConnectToTestDbSybase(t)
+	assert.NotNil(t, conn)
+	defer conn.Close()
+	assert.True(t, conn.isLive())
+	assert.False(t, conn.isDead())
+	assert.True(t, conn.sybaseMode())
+	assert.False(t, conn.sybaseMode125())
+}
+
+func TestConnectSybase125(t *testing.T) {
+	conn := ConnectToTestDbSybase125(t)
+	assert.NotNil(t, conn)
+	defer conn.Close()
+	assert.True(t, conn.isLive())
+	assert.False(t, conn.isDead())
+	assert.True(t, conn.sybaseMode125())
+	assert.False(t, conn.sybaseMode())
 }
 
 func TestItIsSafeToCloseFailedConnection(t *testing.T) {
@@ -151,6 +268,9 @@ func TestReadingTextNtext(t *testing.T) {
 		return
 	}
 	defer conn.Close()
+	if conn.sybaseMode125() {
+		t.Skip("Ntext does not exist in Sybase 12.5")
+	}
 	results, err := conn.Exec(`select top 2 text, ntext from dbo.freetds_types`)
 	assert.Nil(t, err)
 	assert.Equal(t, "išo medo u ducan    5", results[0].Rows[0][0])
@@ -166,8 +286,12 @@ func TestRetryOnKilledConnection(t *testing.T) {
 		return
 	}
 
-	pid1, _ := conn1.SelectValue("select @@spid")
-	conn2.Exec(fmt.Sprintf("kill %d", pid1))
+	if conn1.sybaseMode125() {
+		conn1.Exec("select syb_quit()") //can't kill own session with kill command in sybase, use syb_quit()
+	} else {
+		pid1, _ := conn1.SelectValue("select @@spid")
+		conn2.Exec(fmt.Sprintf("kill %d", pid1))
+	}
 	assert.False(t, conn1.isLive())
 	assert.True(t, conn1.isDead())
 	_, err := conn1.exec("select * from authors")
@@ -202,7 +326,11 @@ func TestExecute(t *testing.T) {
 	rst, err = conn.Exec("sp_help 'authors'")
 	assert.Nil(t, err)
 	assert.NotNil(t, rst)
-	assert.True(t, len(rst) > 7)
+	mincount := 7
+	if conn.sybaseMode125() {
+		mincount = 5
+	}
+	assert.True(t, len(rst) > mincount)
 }
 
 func TestRowsAffected(t *testing.T) {
@@ -359,6 +487,9 @@ func TestTransactionCommitRollback(t *testing.T) {
 func createTestTable2(t *testing.T, conn *Conn, name string, columDef string) {
 	if columDef == "" {
 		columDef = "id int not null identity,  name varchar(255)"
+		if conn.sybaseMode125() {
+			columDef = "id int identity not null,  name varchar(255)"
+		}
 	}
 	sql := fmt.Sprintf(`
 	if exists(select * from sys.tables where name = 'table_name')
@@ -368,7 +499,14 @@ func createTestTable2(t *testing.T, conn *Conn, name string, columDef string) {
     %s
   ) 
   `, columDef)
-	sql = strings.Replace(sql, "table_name", name, 3)
+	if conn.sybaseMode125() {
+		_, _ = conn.Exec(strings.Replace(`if exists(select id from sysobjects where name = 'table_name' and type = 'U')
+	  drop table table_name
+	`, "table_name", name, 2))
+		sql = fmt.Sprintf(`create table table_name ( %s )  `, columDef)
+	}
+
+	sql = strings.Replace(sql, "table_name", name, 1)
 	_, err := conn.Exec(sql)
 	assert.Nil(t, err)
 }
@@ -401,14 +539,14 @@ func TestWrongPassword(t *testing.T) {
 	conn, err := connectWithCredentials(c)
 	assert.NotNil(t, err)
 	assert.Nil(t, conn)
-	assert.True(t, strings.Contains(err.Error(), "Login failed for user"))
+	assert.True(t, strings.Contains(err.Error(), "Login failed"))
 	//t.Logf("wrong password message: %s", err)
 }
 
 func TestLockTimeout(t *testing.T) {
 	connStr := testDbConnStr(1)
 	c := NewCredentials(connStr)
-	c.lockTimeout = 100
+	c.lockTimeout = 1
 	conn, err := connectWithCredentials(c)
 	assert.Nil(t, err)
 	assert.NotNil(t, conn)
@@ -417,14 +555,26 @@ func TestLockTimeout(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, conn2)
 
+	delaySql := "begin transaction; update authors set phone = phone; waitfor delay '00:00:01'; commit transaction"
+	if conn.sybaseMode125() {
+		delaySql = "begin transaction update authors set phone = phone waitfor delay '00:00:03' commit transaction"
+	}
 	go func() {
-		_, err := conn.Exec("begin transaction; update authors set phone = phone; waitfor delay '00:00:01'; commit transaction")
+		_, err := conn.Exec(delaySql)
 		assert.Nil(t, err)
 	}()
 	time.Sleep(1e8)
-	_, err = conn2.Exec("begin transaction; update authors set phone = phone; commit transaction")
+	immediateSql := "begin transaction; update authors set phone = phone; commit transaction"
+	if conn.sybaseMode125() {
+		immediateSql = "begin transaction update authors set phone = phone commit transaction"
+	}
+	_, err = conn2.Exec(immediateSql)
 	assert.NotNil(t, err)
-	assert.True(t, strings.Contains(err.Error(), "Lock request time out period exceeded."))
+	failText := "Lock request time out period exceeded."
+	if conn.sybaseMode125() {
+		failText = "Could not acquire a lock within the specified wait period."
+	}
+	assert.True(t, strings.Contains(err.Error(), failText))
 }
 
 func TestParseFreeTdsVersion(t *testing.T) {
@@ -458,9 +608,15 @@ func longString(size int) string {
 
 func testNvarcharMax(t *testing.T, str string) {
 	c := ConnectToTestDb(t)
-	_, err := c.Exec(fmt.Sprintf("update dbo.freetds_types set nvarchar_max='%s' where int = 3", str))
+	updateSql := "update dbo.freetds_types set nvarchar_max='%s' where int = 3"
+	selectSql := "select nvarchar_max from dbo.freetds_types where int = 3"
+	if c.sybaseMode125() {
+		updateSql = "update freetds_types set nvarchar_max='%s' where int = 3"
+		selectSql = "select nvarchar_max from freetds_types where int = 3"
+	}
+	_, err := c.Exec(fmt.Sprintf(updateSql, str))
 	assert.Nil(t, err)
-	val, err := c.SelectValue("select nvarchar_max from dbo.freetds_types where int = 3")
+	val, err := c.SelectValue(selectSql)
 	assert.Nil(t, err)
 	//t.Logf("nvarchar_max len: %d", len(fmt.Sprintf("%s", val)))
 	strVal, ok := val.(string)
@@ -471,12 +627,22 @@ func testNvarcharMax(t *testing.T, str string) {
 
 func TestTypes(t *testing.T) {
 	c := ConnectToTestDb(t)
-	_, err := c.ExecuteSql("select * from  dbo.freetds_types")
+	sql := "select * from  dbo.freetds_types"
+	var err error
+	if !c.sybaseMode125() {
+		_, err = c.ExecuteSql(sql)
+	} else {
+		sql = "select * from  freetds_types"
+		_, err = c.ExecuteSqlSybase125(sql)
+	}
 	assert.Nil(t, err)
 }
 
 func TestUnknownDataTypeInExecuteSql(t *testing.T) {
 	c := ConnectToTestDb(t)
+	if c.sybaseMode125() {
+		t.Skip("Sybase 12.5 doesn't have sp_executesql")
+	}
 	var str *string
 	_, err := c.ExecuteSql("update dbo.freetds_types set nvarchar_max=? where int = 3", str)
 	assert.NotNil(t, err)

--- a/conn_test.go
+++ b/conn_test.go
@@ -506,7 +506,7 @@ func createTestTable2(t *testing.T, conn *Conn, name string, columDef string) {
 		sql = fmt.Sprintf(`create table table_name ( %s )  `, columDef)
 	}
 
-	sql = strings.Replace(sql, "table_name", name, 1)
+	sql = strings.Replace(sql, "table_name", name, 3)
 	_, err := conn.Exec(sql)
 	assert.Nil(t, err)
 }

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -32,13 +32,15 @@ func testCredentials(t *testing.T, crd *credentials) {
 
 func TestParseConnectionStringCompatibilityMode(t *testing.T) {
 	setDefaultStrings := map[string]string{
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000":                           "",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility_mode=Sybase": "sybase",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility mode=sybase": "sybase",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility Mode=sybase": "sybase",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility_Mode=Sybase": "sybase",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility=Other":       "other",
-		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility=other":       "other",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000":                                "",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility_mode=Sybase":      "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility mode=sybase":      "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility Mode=sybase":      "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility_Mode=Sybase":      "sybase",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility Mode=sybase_12_5": "sybase_12_5",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility_Mode=Sybase_12_5": "sybase_12_5",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;Compatibility=Other":            "other",
+		"Server=myServerAddress;Database=myDataBase;User Id=myUsername;Password=myPassword;Failover Partner=myMirror;Max Pool Size=200;Lock Timeout=1000;compatibility=other":            "other",
 	}
 	for connStr, expected := range setDefaultStrings {
 		crd := NewCredentials(connStr)

--- a/executesql_test.go
+++ b/executesql_test.go
@@ -102,6 +102,13 @@ func TestParseParams(t *testing.T) {
 
 func TestExecuteSqlDatetime(t *testing.T) {
 	c := ConnectToTestDb(t)
-	_, err := c.ExecuteSql("select top 1 datetime from dbo.freetds_types where datetime < ?", time.Now())
+	var err error
+	sql := "select top 1 datetime from dbo.freetds_types where datetime < ?"
+	if !c.sybaseMode125() {
+		_, err = c.ExecuteSql(sql, time.Now())
+	} else {
+		sql = "select top 1 datetime from freetds_types where datetime < ?"
+		_, err = c.ExecuteSqlSybase125(sql, time.Now().Format( "2006-01-02 15:04:05"))
+	}
 	assert.Nil(t, err)
 }

--- a/fetch.go
+++ b/fetch.go
@@ -37,6 +37,9 @@ func (conn *Conn) fetchResults() ([]*Result, error) {
 			if typ == SYBUNIQUE {
 				size = 36
 			}
+			if typ == SYBNUMERIC || typ==SYBDECIMAL {
+				size = 8
+			}
 			bindTyp, typ := dbbindtype(typ)
 			result.addColumn(name, int(size), int(typ))
 			if bindTyp == C.NTBSTRINGBIND && C.SYBCHAR != typ && C.SYBTEXT != typ && XSYBXML != typ {

--- a/mssql_stmt.go
+++ b/mssql_stmt.go
@@ -22,7 +22,11 @@ func (s *MssqlStmt) NumInput() int {
 }
 
 func (s *MssqlStmt) Exec(args []driver.Value) (driver.Result, error) {
-	results, err := s.conn.ExecuteSql(s.query, args...)
+	execSql := s.conn.ExecuteSql
+	if s.conn.sybaseMode125() {
+		execSql = s.conn.ExecuteSqlSybase125
+	}
+	results, err := execSql(s.query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +34,11 @@ func (s *MssqlStmt) Exec(args []driver.Value) (driver.Result, error) {
 }
 
 func (s *MssqlStmt) Query(args []driver.Value) (driver.Rows, error) {
-	results, err := s.conn.ExecuteSql(s.query, args...)
+	execSql := s.conn.ExecuteSql
+	if s.conn.sybaseMode125() {
+		execSql = s.conn.ExecuteSqlSybase125
+	}
+	results, err := execSql(s.query, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -7,14 +7,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"os"
 )
 
-func open() (*sql.DB, error) {
-	return sql.Open("mssql", testDbConnStr(1))
+func open(t *testing.T) (*sql.DB, error, bool) {
+	connStr := os.Getenv("GOFREETDS_CONN_STR")
+	conn, err := NewConn(connStr)
+	//if()
+	if err != nil {
+		t.Error(err)
+	}
+	db, err := sql.Open("mssql", testDbConnStr(1))
+	return db, err, conn.sybaseMode125()
 }
 
 func TestGoSqlOpenConnection(t *testing.T) {
-	db, err := open()
+	db, err, _ := open(t)
 	if err != nil || db == nil {
 		t.Error(err)
 	}
@@ -28,8 +36,18 @@ func TestMssqlConnOpen(t *testing.T) {
 	c.Close()
 }
 
+func TestMssqlConnOpenSybase125(t *testing.T) {
+	d := &MssqlDriver{}
+	c, err := d.Open(testDbConnStrSybase125(1))
+	assert.Nil(t, err)
+	assert.IsType(t, &MssqlConn{}, c)
+	c.Close()
+}
+
+
 func TestGoSqlDbQueryRow(t *testing.T) {
-	db, err := open()
+	db, err, _ := open(t)
+	defer db.Close()
 	assert.Nil(t, err)
 	row := db.QueryRow("SELECT au_fname, au_lname name FROM authors WHERE au_id = ?", "172-32-1176")
 	var firstName, lastName string
@@ -40,7 +58,8 @@ func TestGoSqlDbQueryRow(t *testing.T) {
 }
 
 func TestGoSqlDbQuery(t *testing.T) {
-	db, err := open()
+	db, err, _ := open(t)
+	defer db.Close()
 	assert.Nil(t, err)
 	rows, err := db.Query("SELECT au_fname, au_lname name FROM authors WHERE au_lname = ? order by au_id", "Ringer")
 	assert.Nil(t, err)
@@ -61,7 +80,8 @@ func testRingers(t *testing.T, rows *sql.Rows) {
 
 func TestGoSqlPrepareQuery(t *testing.T) {
 	//t.Skip()
-	db, err := open()
+	db, err, _ := open(t)
+	defer db.Close()
 	assert.Nil(t, err)
 	assert.NotNil(t, db)
 	stmt, err := db.Prepare("SELECT au_fname, au_lname name FROM authors WHERE au_lname = ? order by au_id")
@@ -72,9 +92,13 @@ func TestGoSqlPrepareQuery(t *testing.T) {
 }
 
 func TestLastInsertIdRowsAffected(t *testing.T) {
-	db, _ := open()
-	createTestTable(t, db, "test_last_insert_id", "")
-	r, err := db.Exec("insert into test_last_insert_id values(?)", "pero")
+	db, _, sybase125 := open(t)
+	defer db.Close()
+	if sybase125 {
+		t.Skip("LastInsertId and RowsEffective not returned in Sybase 12.5")
+	}
+	createTestTable(t, db, sybase125,"test_last_insert_id", "")
+	r, err := db.Exec("insert into [test_last_insert_id] values(?)", "pero")
 	assert.Nil(t, err)
 	assert.NotNil(t, r)
 	id, err := r.LastInsertId()
@@ -110,10 +134,14 @@ func TestLastInsertIdRowsAffected(t *testing.T) {
 	assert.EqualValues(t, ra, 2)
 }
 
-func createTestTable(t *testing.T, db *sql.DB, name string, columDef string) {
+func createTestTable(t *testing.T, db *sql.DB, sybase125 bool, name string, columDef string) {
 	if columDef == "" {
 		columDef = "id int not null identity,  name varchar(255)"
+		if sybase125 {
+			columDef = "id int identity not null,  name varchar(255)"
+		}
 	}
+
 	sql := fmt.Sprintf(`
 	if exists(select * from sys.tables where name = 'table_name')
 	  drop table table_name
@@ -122,14 +150,32 @@ func createTestTable(t *testing.T, db *sql.DB, name string, columDef string) {
     %s
   ) 
   `, columDef)
+
+	if sybase125 {
+		sql = `
+		if exists(select name from sysobjects where name = "table_name")
+	  drop table table_name 
+		`
+		sql = strings.Replace(sql, "table_name", name, 2)
+		result, err := db.Exec(sql)
+		result = result
+		assert.Nil(t, err)
+
+		sql = fmt.Sprintf(`
+		create table [table_name] ( 
+		%s 
+		)
+		`, columDef)
+	}
 	sql = strings.Replace(sql, "table_name", name, 3)
 	_, err := db.Exec(sql)
 	assert.Nil(t, err)
 }
 
 func TestTransCommit(t *testing.T) {
-	db, _ := open()
-	createTestTable(t, db, "test_tran", "")
+	db, _, sybase125 := open(t)
+	defer db.Close()
+	createTestTable(t, db, sybase125, "test_tran", "")
 	tx, err := db.Begin()
 	assert.Nil(t, err)
 	tx.Exec("insert into test_tran values(?)", "pero")
@@ -145,8 +191,9 @@ func TestTransCommit(t *testing.T) {
 }
 
 func TestTransRollback(t *testing.T) {
-	db, _ := open()
-	createTestTable(t, db, "test_tran", "")
+	db, _, sybase125 := open(t)
+	defer db.Close()
+	createTestTable(t, db, sybase125, "test_tran", "")
 	tx, err := db.Begin()
 	assert.Nil(t, err)
 	tx.Exec("insert into test_tran values(?)", "pero")
@@ -162,8 +209,14 @@ func TestTransRollback(t *testing.T) {
 }
 
 func TestBlobs(t *testing.T) {
-	db, _ := open()
-	createTestTable(t, db, "test_blobs", "id int identity, blob varbinary(16), blob2 varbinary(MAX)")
+	db, _, sybase125 := open(t)
+	defer db.Close()
+	columnDef := "id int identity, blob varbinary(16), blob2 varbinary(MAX)"
+	if sybase125 {
+		columnDef = "id int identity, blob image, blob2 image"
+		//t.Skip("Blobs not supported in Sybase 12.5")
+	}
+	createTestTable(t, db, sybase125, "test_blobs", columnDef)
 	want := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}
 	_, err := db.Exec("insert into test_blobs values(?, ?)", want, want)
 	assert.Nil(t, err)


### PR DESCRIPTION
Handling allowances for Sybase ASE 12.5 when functioning as a driver via sql/sqlx

Using dsn argument `Compatibility Mode=Sybase_12_5` instead of `Compatibility Mode=Sybase` when connecting to a 12.5 system

This is needed for Pre-v15 Sybase ASE because `sp_executesql` does not exist in the older versions (12.5 being my target server)