### PR TITLE
Bugfix go2SqlDataType was returning too large of a varbinary

### DIFF
--- a/executesql.go
+++ b/executesql.go
@@ -141,6 +141,11 @@ func go2SqlDataType(value interface{}) (string, string, error) {
 	case []byte:
 		{
 			b, _ := value.([]byte)
+			if(max(1, len(b)) > 8000) {
+				return "varbinary (MAX)",
+					fmt.Sprintf("0x%x", b), nil
+			}
+
 			return fmt.Sprintf("varbinary (%d)", max(1, len(b))),
 				fmt.Sprintf("0x%x", b), nil
 		}

--- a/executesql.go
+++ b/executesql.go
@@ -141,7 +141,7 @@ func go2SqlDataType(value interface{}) (string, string, error) {
 	case []byte:
 		{
 			b, _ := value.([]byte)
-			if(max(1, len(b)) > 8000) {
+			if len(b) > 8000 {
 				return "varbinary (MAX)",
 					fmt.Sprintf("0x%x", b), nil
 			}

--- a/executesql_test.go
+++ b/executesql_test.go
@@ -1,6 +1,7 @@
 package freetds
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -80,6 +81,7 @@ func TestGoTo2SqlDataType(t *testing.T) {
 	checker(tm.In(paris), "datetimeoffset", "'"+tm.In(paris).Format(sqlDateTimeOffSet)+"'")
 
 	checker([]byte{1, 2, 3, 4, 5, 6, 7, 8}, "varbinary (8)", "0x0102030405060708")
+	checker(make([]byte, 8001), "varbinary (MAX)", "0x" + strings.Repeat("00", 8001))
 
 	checker("", "nvarchar (1)", "''")
 	checker(true, "bit", "1")


### PR DESCRIPTION
The go2sqlDataType function would return a varbinary of any length in a screen,
however, 8000 is the maximum size any varbinary data type can be.
Source: https://docs.microsoft.com/en-us/sql/t-sql/data-types/binary-and-varbinary-transact-sql?view=sql-server-ver15

To be larger than 8000, it must be a varbinary (MAX). Otherwise, this would cause an error when calling conn.ExecuteSql with a byte slice with a greater length than 8000.
I've made this adjustment and added a test to make sure it keeps working.