### PR TITLE
Handle nil params in ExecuteSql

### DIFF
--- a/executesql.go
+++ b/executesql.go
@@ -114,6 +114,8 @@ func go2SqlDataType(value interface{}) (string, string, error) {
 
 	strValue := fmt.Sprintf("%v", value)
 	switch t := value.(type) {
+	case nil:
+		return "nvarchar (1)", "NULL", nil
 	case bool:
 		bitStrValue := "0"
 		if strValue == "true" {

--- a/executesql_test.go
+++ b/executesql_test.go
@@ -82,6 +82,7 @@ func TestGoTo2SqlDataType(t *testing.T) {
 	checker([]byte{1, 2, 3, 4, 5, 6, 7, 8}, "varbinary (8)", "0x0102030405060708")
 
 	checker("", "nvarchar (1)", "''")
+	checker(nil, "nvarchar (1)", "NULL")
 	checker(true, "bit", "1")
 	checker(false, "bit", "0")
 }


### PR DESCRIPTION
Issue #29 

I have tested this with Sybase 12.5, However not with other versions of Sybase/MSSQL.

I took a tip from go-mssqldb where it associates null with "nvarchar(1)", though I am not exactly sure if it's the same context.
https://github.com/denisenkom/go-mssqldb/blob/b91950f658ecd54342d783495e1aadf48a55e967/types.go#L1124