### PR TITLE
fix: add sybase 12.5 LastInsertedId() support

### DIFF
--- a/executesql.go
+++ b/executesql.go
@@ -13,8 +13,8 @@ const statusRow string = `;
           cast(@@rowcount as bigint) rows_affected
 `
 const statusRowSybase125 string = `
-   select cast(coalesce(@@IDENTITY, -1) as bigint) last_insert_id, 
-          cast(@@rowcount as bigint) rows_affected
+   select cast(coalesce(@@IDENTITY, -1) as int) last_insert_id, 
+          cast(@@rowcount as int) rows_affected
 `
 
 //Execute sql query with arguments.

--- a/mssql_stmt.go
+++ b/mssql_stmt.go
@@ -119,6 +119,9 @@ func (r *MssqlResult) statusRowValue(columnName string) int64 {
 		if val, ok := lastResult.Rows[0][idx].(float64); ok {
 			return int64(val)
 		}
+		if val, ok := lastResult.Rows[0][idx].(int32); ok {
+			return int64(val)
+		}
 	}
 	return -1
 }

--- a/mssql_test.go
+++ b/mssql_test.go
@@ -3,11 +3,11 @@ package freetds
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"os"
 )
 
 func open(t *testing.T) (*sql.DB, error, bool) {
@@ -43,7 +43,6 @@ func TestMssqlConnOpenSybase125(t *testing.T) {
 	assert.IsType(t, &MssqlConn{}, c)
 	c.Close()
 }
-
 
 func TestGoSqlDbQueryRow(t *testing.T) {
 	db, err, _ := open(t)
@@ -94,10 +93,7 @@ func TestGoSqlPrepareQuery(t *testing.T) {
 func TestLastInsertIdRowsAffected(t *testing.T) {
 	db, _, sybase125 := open(t)
 	defer db.Close()
-	if sybase125 {
-		t.Skip("LastInsertId and RowsEffective not returned in Sybase 12.5")
-	}
-	createTestTable(t, db, sybase125,"test_last_insert_id", "")
+	createTestTable(t, db, sybase125, "test_last_insert_id", "")
 	r, err := db.Exec("insert into [test_last_insert_id] values(?)", "pero")
 	assert.Nil(t, err)
 	assert.NotNil(t, r)
@@ -122,7 +118,9 @@ func TestLastInsertIdRowsAffected(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, r)
 	id, err = r.LastInsertId()
-	assert.NotNil(t, err)
+	if !sybase125 {
+		assert.NotNil(t, err)
+	}
 	ra, err = r.RowsAffected()
 	assert.Nil(t, err)
 	assert.EqualValues(t, ra, 2)


### PR DESCRIPTION
adds (some) LastInsertedId() support for the sybase 12.5 compatibility mode. statusRowSybase125 will now be used in the executed sql. it will cast the returned values to int64s that can be cast from in mssql_stmt.go

Support is not perfect because LastInsertedId() returns the last inserted id from the whole connection, not just the scope of the sql statements.